### PR TITLE
Use lowercase GitHub username to find file in registry

### DIFF
--- a/R/monorepos.R
+++ b/R/monorepos.R
@@ -241,7 +241,7 @@ print_message <- function(...){
 
 read_registry_list <- function(){
   monorepo_url <- gert::git_remote_info()$url
-  jsonfile <- sprintf('.registry/%s.json', sub("_", "@", basename(monorepo_url), fixed = TRUE))
+  jsonfile <- sprintf('.registry/%s.json', sub("_", "@", tolower(basename(monorepo_url)), fixed = TRUE))
   if(file.exists(jsonfile)){
     jsonlite::read_json(jsonfile)
   } else {


### PR DESCRIPTION
Hi,

I'm not 100% sure of the fix but it looks like r-universes for users or orgs with uppercase characters in their name don't sync properly.

e.g.

- https://github.com/r-universe/Bisaloo ([file in registry](https://github.com/r-universe-org/cran-to-git/blob/master/bisaloo.json))

- https://github.com/r-universe/Appsilon ([file in registry](https://github.com/r-universe-org/cran-to-git/blob/master/appsilon.json))

I think the issue comes from the fact that files in the registry are lowercased and repositories in r-universe use the raw GH username, which can have uppercase characters.

This PR proposes one way to fix this issue but you might prefer another one.